### PR TITLE
feat: display unit information for misc resources

### DIFF
--- a/pages/planning.tsx
+++ b/pages/planning.tsx
@@ -114,6 +114,7 @@ const Planning = () => {
           <input className={planningStyles['misc-resource']}
                  type="checkbox"
                  onChange={(event) => changeMiscQuantity(key, event.target.checked)}/>
+          <span className={planningStyles.detail}>({value.weight}&nbsp;units)</span>
           <span className={planningStyles['dotted-underline']}/>
           <span className={planningStyles.quantity}>{(warehouse.resources[key]?.quantity | 0) * resources[key].price}$</span>
         </div>

--- a/styles/Planning.module.scss
+++ b/styles/Planning.module.scss
@@ -45,12 +45,13 @@
 
 .misc-resource {
   width: 20px;
+  height: 20px;
 }
 
 .dotted-underline {
   flex: 1;
   border-bottom: 1px black dashed;
-  margin: 10px 10px 0;
+  margin: 5px 10px;
 }
 
 .resource-picker {
@@ -98,4 +99,8 @@
 .misc-resource:checked:before {
   background-image:url("../public/svg/checkbox-checked.svg");
   appearance: none;
+}
+
+.detail {
+  margin-left: 10px;
 }


### PR DESCRIPTION
Fixes #6 

I added the unit information next to the checkbox, to be more similar to the unit selection above.

![image](https://user-images.githubusercontent.com/17448533/139596495-447cebf6-c11c-4fd1-b0bb-5717d7c50f18.png)
